### PR TITLE
Fixed empty source view in getSource.php

### DIFF
--- a/site/getSource.php
+++ b/site/getSource.php
@@ -10,9 +10,26 @@
         $res = mysqli_query($link, $query);
         if (mysqli_num_rows($res) == 1 && !(($file = @file_get_contents("./executions/".$id)) === FALSE))
         {
-            $file = "<code>" . nl2br(str_replace(" ", "&nbsp;", 
-                str_replace("\t", "    ", htmlspecialchars($file)))) . "</code>";
-            echo $file;
+            
+            // in php >= 5.6 we need to set encoding for htmlspecialchars!
+            $encodings = array('UTF-8', 'CP1251', 'ISO-8859-1', 'KOI8-R');
+            
+            foreach ($encodings as $encoding)
+            {
+               
+                $editedCode = nl2br(str_replace(" ", "&nbsp;", 
+                    str_replace("\t", "    ", htmlspecialchars($file, ENT_COMPAT | ENT_HTML401, $encoding))));
+                    
+                    
+                if (!empty($editedCode)) 
+                {
+                    echo '<code>' . $editedCode . '</code>';
+                    break;
+                }
+
+                
+            }
+
         }
     }
 ?>


### PR DESCRIPTION
Нашел баг, когда не выводились стратегии пользователей при нажатии ссылки "Показать код" в стратегиях игроков. В версиях php >= 5.6 выяснилось, что в функции `htmlspecialchars` поменяли кодировку по умолчанию, и получается, что если в строке при указанной кодировке что-то пошло не так (символы не так прочитались), то возвращается пустая  строка.

В итоге проверяю на нескольких кодировках в цикле результат данной функции и, возможно, нужно применить данную методику и в остальных местах, где используется функция `htmlspecialchars`!
