### PR TITLE
Fixed missing name in destroy DB checkbox

### DIFF
--- a/site/install.php
+++ b/site/install.php
@@ -59,7 +59,7 @@
                     <div class="row">
                         <div class="checkbox">
                             <label>
-                                <input type="checkbox"> Remove existing DB
+                                <input type="checkbox" name="destroyDB"> Remove existing DB
                             </label>
                         </div>
                     </div>


### PR DESCRIPTION
Забыл указать `name` в чекбоксе удаления баз данных - из-за этого БД при инсталляции не удалялась.
